### PR TITLE
draft: macros, error ideas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 login_info*
+*.lock
+**/*.rs.bk
+Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1713,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,7 +2028,9 @@ name = "suplex"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "lazy_static",
  "quick-xml",
+ "regex",
  "reqwest",
  "serde",
  "serde-xml-rs",

--- a/suplex/Cargo.toml
+++ b/suplex/Cargo.toml
@@ -14,3 +14,5 @@ serde = {version = "1", features=["derive"]}
 serde-xml-rs = "0.6"
 tokio = {version = "1"}
 thiserror = "1.0"
+regex = "1.6.0"
+lazy_static = "1.4.0"

--- a/suplex/src/plex_user.rs
+++ b/suplex/src/plex_user.rs
@@ -1,10 +1,14 @@
+//!
+//! Suplex `PlexUser`
+//!
 use crate::util::{
-    apply_plex_client_identifier, apply_plex_product, apply_plex_version, extract_xml_attr, Result,
+    apply_plex_client_identifier, apply_plex_product, apply_plex_version, Result, REGEX_SET,
 };
-use crate::SuplexError;
+use crate::{build_plex_user_add_fn, xml_match_attrs, SuplexError};
 
 use quick_xml::events::Event;
 use quick_xml::reader::Reader;
+use regex::Regex;
 use reqwest::header::HeaderMap;
 
 #[derive(Default, Debug, Clone)]
@@ -31,9 +35,17 @@ impl PlexUser {
         if let Ok(text) = result {
             println!("{}", text);
             if let Ok(result) = Self::_from_xml_text(text).await {
+                //if let Ok(Self::build_with_regex(&text)){ // Absolutely not faster :(
                 Some(result)
             } else {
                 // TODO: Log the error...?
+                // NOTE: I actually think custom result types would be nicer here, see the
+                // additions to SuplexError I added, you'd construct them like this:
+                //  Err(SuplexError::FetchFailure {
+                //      code: 400,
+                //      msg: "bad request".to_string(),
+                //  });
+                // which would let you have the codes you mentioned in a nice way maybe?
                 None
             }
         } else {
@@ -41,6 +53,12 @@ impl PlexUser {
             None
         }
     }
+
+    // This will build an add method, which add's &str to a PlexUser's appropriate field by
+    // matching substrings.
+    build_plex_user_add_fn!(
+        "email", email, "username", username, "title", title, "en", auth_token, "uuid", uuid
+    );
 
     async fn _try_login<T>(username: &T, password: &T) -> Result<String>
     where
@@ -73,37 +91,47 @@ impl PlexUser {
             match reader.read_event() {
                 Err(e) => return Err(SuplexError::XmlError { source: e }),
                 Ok(Event::Eof) => break,
-                Ok(Event::Start(e)) => match e.name().as_ref() {
-                    b"user" => {
-                        // id
-                        extract_xml_attr!(id, e, plex_user);
-
-                        // uuid
-                        if let Some(attr) = e.try_get_attribute("uuid")? {
-                            plex_user.uuid = attr.unescape_value()?.to_string();
-                        }
-
-                        // id
-                        if let Some(attr) = e.try_get_attribute("email")? {
-                            plex_user.email = attr.unescape_value()?.to_string();
-                        }
-
-                        // username
-                        if let Some(attr) = e.try_get_attribute("username")? {
-                            plex_user.username = attr.unescape_value()?.to_string();
-                        }
-
-                        // authToken
-                        // TODO: The current macro won't handle this because the two are different
-                        if let Some(attr) = e.try_get_attribute("authToken")? {
-                            plex_user.auth_token = attr.unescape_value()?.to_string();
-                        }
-                    }
-                    _ => (),
-                },
+                Ok(Event::Start(e)) => {
+                    xml_match_attrs!(plex_user, e, "id", "uuid", "username", "authToken")
+                }
                 _ => (),
             }
         }
         Ok(plex_user)
+    }
+    // INNER -- create Self from XML text String
+    /// Builds a [`PlexUser`] using Regexes and String-matching, rather than the
+    /// [`from_xml_text()`]'s line-by-line approach.
+    pub fn _build_with_regex(xml: &str) -> Result<Self> {
+        // //TODO: lazy static this -- it's bad if they're re-compiled in a loop.
+        // let set = RegexSet::new(&[
+        //     r#"(email="[a-z]+@[a-z]+.[a-z]+)"#,
+        //     r#"(id="\d+")"#,
+        //     r#"(uuid="\w+")"#,
+        //     r#"(username="\w+")"#,
+        //     r#"(title="\w+")"#,
+        //     r#"(authToken="\w+")"#, //NOTE: there's many.. variants of this?
+        // ])?;
+
+        let regexes: Vec<_> = REGEX_SET
+            .patterns()
+            // .into_par_iter() // t1.elapsed().as_nanos() = 2459129
+            .into_iter() // t1.elapsed().as_nanos() = 1602265
+            .map(|pat| Regex::new(pat).unwrap())
+            .collect();
+
+        let mut pu = PlexUser {
+            ..Default::default()
+        };
+
+        REGEX_SET
+            .matches(&xml)
+            .into_iter()
+            .map(|match_idx| &regexes[match_idx])
+            .flat_map(|pat| pat.find(&xml))
+            .for_each(|res| {
+                _ = pu.add(res.as_str());
+            });
+        Ok(pu)
     }
 }

--- a/suplex/src/plex_user.rs
+++ b/suplex/src/plex_user.rs
@@ -103,20 +103,10 @@ impl PlexUser {
     /// Builds a [`PlexUser`] using Regexes and String-matching, rather than the
     /// [`from_xml_text()`]'s line-by-line approach.
     pub fn _build_with_regex(xml: &str) -> Result<Self> {
-        // //TODO: lazy static this -- it's bad if they're re-compiled in a loop.
-        // let set = RegexSet::new(&[
-        //     r#"(email="[a-z]+@[a-z]+.[a-z]+)"#,
-        //     r#"(id="\d+")"#,
-        //     r#"(uuid="\w+")"#,
-        //     r#"(username="\w+")"#,
-        //     r#"(title="\w+")"#,
-        //     r#"(authToken="\w+")"#, //NOTE: there's many.. variants of this?
-        // ])?;
-
         let regexes: Vec<_> = REGEX_SET
             .patterns()
             // .into_par_iter() // t1.elapsed().as_nanos() = 2459129
-            .into_iter() // t1.elapsed().as_nanos() = 1602265
+            .iter() // t1.elapsed().as_nanos() = 1602265
             .map(|pat| Regex::new(pat).unwrap())
             .collect();
 
@@ -125,10 +115,10 @@ impl PlexUser {
         };
 
         REGEX_SET
-            .matches(&xml)
-            .into_iter()
+            .matches(xml)
+            .iter()
             .map(|match_idx| &regexes[match_idx])
-            .flat_map(|pat| pat.find(&xml))
+            .flat_map(|pat| pat.find(xml))
             .for_each(|res| {
                 _ = pu.add(res.as_str());
             });

--- a/suplex/src/util.rs
+++ b/suplex/src/util.rs
@@ -1,19 +1,75 @@
+use lazy_static::lazy_static;
+use regex::Error as RegXError;
+use regex::RegexSet;
 use reqwest::header::HeaderMap;
 use std::num::ParseIntError;
 use thiserror;
 
-macro_rules! extract_xml_attr {
-    ($attrib_name:ident, $e:ident, $plex_user:ident) => {
-        if let Some(attr) = $e.try_get_attribute(String::from(stringify!($attrib_name)))? {
-            $plex_user.$attrib_name = attr.unescape_value()?.to_string().parse()?;
+#[macro_export]
+/// Expands all the potential xml<attribute> tags into a collection of `if-let`s to parse strings
+/// and assign field values to [`PlexUser`]s.
+macro_rules! xml_match_attrs {
+    ($plex_user:expr, $e:expr, $($tag:expr),*) => {{
+        if let b"user" = $e.name().as_ref() {
+            $( if let Some(attr) = $e.try_get_attribute($tag)? {
+                $plex_user.id = attr.unescape_value()?.to_string().parse()?;
+            })*
         }
-    };
-}
+    }};
+    }
 
-pub(crate) use extract_xml_attr;
+/// Generates the code for the [`PlexUser::Add`] method.
+/// Uses regex matches and string matching to populate the correct field for the provided &str.
+#[macro_export]
+macro_rules! build_plex_user_add_fn {
+    ($($tag:expr, $field:ident),*) => {
+    /// Adds a field value to the right spot in a [`PlexUser`] my matching contents of a &str.
+    /// powered by regexes.
+    fn add(&mut self, reg_match: &str) -> Result<()> {
+            $(if reg_match.contains($tag) {
+                if let Some(v) = reg_match.split('=').last() {
+                    self.$field= v.trim().trim_matches('"').to_string();
+                }
+            })*
+            // This one's irregular, so it gets hardcoded.
+            if reg_match.contains("id") && !reg_match.contains("uu"){
+                if let Some(v) = reg_match.split('=').last() {
+                    self.id = v.trim().trim_matches('"').parse::<u64>()?;
+                }
+            }
+            Ok(())
+            }
+        };
+
+}
+#[macro_export]
+/// Implements clone for a type you pass to it.
+macro_rules! impl_clone_for{
+    ($($t:ty),*) =>
+    {
+        $(impl Copy for $t{})*
+
+        $(impl Clone for $t{
+            fn clone(&self) -> Self{
+                *self
+            }
+        })*
+    }
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum SuplexError {
+    // Ours:
+    #[error("Failed to update\ncode:{code}\nmsg:{msg}")]
+    UpdateFailure { code: u16, msg: String },
+
+    #[error("Failed to fetch data \ncode:{code}\nmsg:{msg}")]
+    FetchFailure { code: u16, msg: String },
+
+    #[error("The requested resource could not be found,\nmsg:{msg}")]
+    NotFound { code: u16, msg: String },
+
+    // Exporting errors
     #[error("unable to deserialize a response")]
     SerdeDeserializeError {
         #[from]
@@ -34,6 +90,11 @@ pub enum SuplexError {
         #[from]
         source: ParseIntError,
     },
+    #[error("Regex Error, syntax or size related no doubt...")]
+    RegexError {
+        #[from]
+        source: RegXError,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, SuplexError>;
@@ -48,4 +109,16 @@ pub(crate) fn apply_plex_version(headers: &mut HeaderMap) {
 
 pub(crate) fn apply_plex_client_identifier(headers: &mut HeaderMap) {
     headers.insert("X-Plex-Client-Identifier", "12345abcdez".parse().unwrap());
+}
+
+lazy_static! {
+    pub(crate) static ref REGEX_SET: RegexSet =
+        RegexSet::new(&[
+            r#"(email="[a-z]+@[a-z]+.[a-z]+)"#,
+            r#"(id="\d+")"#,
+            r#"(uuid="\w+")"#,
+            r#"(username="\w+")"#,
+            r#"(title="\w+")"#,
+            r#"(authToken="\w+")"#, //NOTE: there's many.. variants of this?
+        ]).expect("Error compiling regexes, probably you've made a syntax error. ");
 }

--- a/suplex/src/util.rs
+++ b/suplex/src/util.rs
@@ -113,7 +113,7 @@ pub(crate) fn apply_plex_client_identifier(headers: &mut HeaderMap) {
 
 lazy_static! {
     pub(crate) static ref REGEX_SET: RegexSet =
-        RegexSet::new(&[
+        RegexSet::new([
             r#"(email="[a-z]+@[a-z]+.[a-z]+)"#,
             r#"(id="\d+")"#,
             r#"(uuid="\w+")"#,


### PR DESCRIPTION
# what's in there?
* some macros: one for the `attr` generation, one for `PlexUser::add` which helps the alternate (regex-based) `builder`, some for deriving `clone` (if you wanna try it on errors later)
* some error ideas -- there's more power in `thiserror` to be had (maybe?)
* updates to the .gitignore
* `clippy` & `cargo fmt` action.
* Docs.

Reject if you don't like etc -- it's mostly just throwing ideas out there.